### PR TITLE
fix(e2e): fix the broken e2e workflow

### DIFF
--- a/e2e/manifests/socks5-proxy.yaml
+++ b/e2e/manifests/socks5-proxy.yaml
@@ -16,8 +16,14 @@ spec:
     spec:
       containers:
         - name: socks5-proxy
-          image: serjs/go-socks5-proxy
+          # The image is pinned by digest: the floating "latest" tag was
+          # replaced on 2025-10-09 with an implementation whose REQUIRE_AUTH
+          # defaults to true, which crashes without PROXY_USER/PROXY_PASSWORD.
+          image: serjs/go-socks5-proxy@sha256:0af522996f402c03ecd985a87997158eabeb28935365e3a384df37eafcf740ea
           imagePullPolicy: IfNotPresent
+          env:
+            - name: REQUIRE_AUTH
+              value: "false"
           ports:
             - containerPort: 1080
               name: socks

--- a/e2e/manifests/waq.yaml
+++ b/e2e/manifests/waq.yaml
@@ -48,6 +48,10 @@ spec:
         - name: ca-bundle
           configMap:
             name: ca-bundle
+      # Shorten the termination grace period so that scale-downs in the e2e
+      # tests remove the old pod quickly; each test recreates the pod from a
+      # freshly reset database anyway.
+      terminationGracePeriodSeconds: 3
 ---
 apiVersion: v1
 kind: Secret

--- a/e2e/src/common.ml
+++ b/e2e/src/common.ml
@@ -130,6 +130,20 @@ module Internal = struct
         ignore
       |> fst |> expect_wexited_0
     in
+    (* Wait until every waq-web pod is completely deleted. Otherwise, during
+       the termination grace period, a request may still be load-balanced to a
+       terminating pod. That breaks the streaming tests in particular: the
+       WebSocket connection and the API request can hit different pods, so
+       streaming events are never delivered to the WebSocket. *)
+    let () =
+      kubectl
+        [
+          "wait"; "--for=delete"; "pod"; "-l"; "app=waq-web"; "-n"; "e2e";
+          "--timeout=60s";
+        ]
+        ignore
+      |> fst |> expect_wexited_0
+    in
     let _ =
       kubectl [ "delete"; "job"; "reset-waq-database"; "-n"; "e2e" ] ignore
     in

--- a/e2e/src/waq_mstdn_14_preview_card.ml
+++ b/e2e/src/waq_mstdn_14_preview_card.ml
@@ -1,6 +1,6 @@
 open Common2
 
-let get_preview_card_from_a1 env (a0 : agent) (a1 : agent) content =
+let get_preview_card_from_a1 ?(wait_for_card = false) env (a0 : agent) (a1 : agent) content =
   (* a1: Follow a0 *)
   follow_agent env a1 a0;
 
@@ -8,14 +8,25 @@ let get_preview_card_from_a1 env (a0 : agent) (a1 : agent) content =
   let { uri; _ } = post env a0 ~content () in
   Eio.Time.sleep (Eio.Stdenv.clock env) 2.0;
 
-  (* a1: Check the post. The post should have been fetched in advance because a1 follows a0. *)
-  let _, [ s ], _ = search env a1 uri in
-  s
+  (* a1: Check the post. The post should have been fetched in advance because a1 follows a0.
+
+     Preview cards are generated asynchronously by crawling the linked page
+     (e.g. www.youtube.com), which can take more than the sleep above
+     depending on the external site's response time. When [wait_for_card] is
+     set, retry the search until the card shows up. *)
+  let rec loop i =
+    let _, [ s ], _ = search env a1 uri in
+    if (not wait_for_card) || Option.is_some s.card || i = 0 then s
+    else (
+      Eio.Time.sleep (Eio.Stdenv.clock env) 2.0;
+      loop (i - 1))
+  in
+  loop 10
 [@@warning "-8"]
 
 let f_case1 env (a0 : agent) (a1 : agent) =
   let url = "https://www.youtube.com/watch?v=OMv_EPMED8Y" in
-  let s = get_preview_card_from_a1 env a0 a1 url in
+  let s = get_preview_card_from_a1 ~wait_for_card:true env a0 a1 url in
   assert (Option.is_some s.card);
   let c = Option.get s.card in
   assert (c.url = url);


### PR DESCRIPTION
## Summary

Fix the e2e workflow that has been failing on every branch (including master) since late 2025. Investigation found three independent problems; this PR fixes all of them.

## Root cause 1: socks5-proxy container crash on startup

Every e2e run used to fail at the first HTTP request (`POST https://waq.waq-e2e.anqou.net/api/v1/statuses`) with `connection refused`. Test traffic goes through `kneesocks` → `127.0.0.1:1080` → `kubectl port-forward deploy/socks5-proxy` → the socks5-proxy pod → cluster Services. The port-forward itself was established, but connecting to port 1080 inside the pod was refused, i.e. the socks5-proxy container was not running.

The manifest used the floating `latest` tag of `serjs/go-socks5-proxy`. That tag was replaced on 2025-10-09 with a new implementation (serjs/socks5-server, runs as non-root 65532) whose `REQUIRE_AUTH` **defaults to `true`**. Without `PROXY_USER`/`PROXY_PASSWORD` the container exits immediately:

```
Error: REQUIRE_AUTH is true, but PROXY_USER and PROXY_PASSWORD are not set.  The application will now exit.
```

Timeline matches: the last successful e2e run was 2025-09-21 (master @ 9defe02); every run since 2025-12-25 fails, with no e2e-related changes in the repo in between.

**Fix**: pin the image by digest and set `REQUIRE_AUTH=false` (verified locally: the container then listens on `0.0.0.0:1080`). The e2e cluster is an isolated kind cluster on CI, so unauthenticated SOCKS access is acceptable.

## Root cause 2: streaming tests hit a pod-replacement race

With the proxy fixed, the streaming tests (`waq-2-1`, `waq-2-2`) still failed intermittently: the WebSocket upgrade succeeded (101), but no `update` event arrived and the connection died with `End_of_file` ~10s later.

Reproduced on a local kind cluster: per-pod logs showed that during the per-test scale-down/scale-up of `waq-web`, the WebSocket GET was load-balanced to the **terminating old pod** (which answered the 101) while the POST landed on the **new pod**. Streaming connections live in pod memory, so the update event pushed by the new pod never reached the WebSocket on the old pod; the EOF arrived when the old pod was finally reaped at the end of its termination grace period.

**Fix**:
- `e2e/src/common.ml`: after scaling `waq-web` down, wait for every pod to be fully deleted (`kubectl wait --for=delete pod -l app=waq-web`) before recreating it
- `e2e/manifests/waq.yaml`: shorten `terminationGracePeriodSeconds` to 3 so the wait does not stall for the default 30s grace period on every testcase

Verified locally: the failing sequence (`waq-1` → `waq-2-1`) failed ~50% of the time before the fix and passed 5/5 runs after it.

## Root cause 3: preview-card test raced against an external crawl

The last failing testcase, `03-preview-card-mstdn-waq`, posts a YouTube URL to Mastodon and checks 2s later that waq attached a preview card. waq generates cards by crawling the linked page, and on CI the crawl (two sequential fetches to www.youtube.com) finished *after* the test's search response, so the assertion saw `card: null` even though the card was inserted moments later.

**Fix**: when `wait_for_card` is set, the helper retries the search (up to 10 times, 2s apart) until the card shows up. Verified locally for both the waq-waq and mstdn-waq variants.

## Verification

- Local kind cluster: the previously failing sequences now pass repeatedly
- CI progression as each fix landed: 0/43 testcases (proxy dead) → 12/43 (first streaming failure) → 42/43 (only the preview-card test) → **43/43, all checks green** (`e2e-test` 38m, `test` 3m)