### PR TITLE
ci: run e2e tests on arm64 runners

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -10,11 +10,19 @@ permissions: read-all
 
 jobs:
   e2e-test:
-    runs-on: ubuntu-latest
+    name: e2e-test - ${{ matrix.platform }}
+    runs-on: ${{ contains(matrix.platform, 'arm64') && 'ubuntu-26.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Checkout tree
         uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14

--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,7 @@
               kind
               kubectl
               kubernetes-helm
+              lsof
               (callPackage ./nix/kneesocks.nix {})
             ]);
         };


### PR DESCRIPTION
Matrix the e2e-test job over linux/amd64 and linux/arm64 using the
same platform + inline-ternary runs-on mapping as _build-nix-app.yml
(arm64 runs natively on ubuntu-26.04-arm; no emulation). fail-fast is
disabled so an arm64-only failure does not cancel the amd64 job, and a
60-minute timeout bounds the unguarded `until kubectl ...` loops in
e2e/Makefile. install-nix-action is bumped to v31, the only version
with a track record on the ubuntu-26.04-arm image.

lsof is added to the dev shell because e2e/Makefile probes port 1080
with it and its absence on the arm runner would silently fall through
to starting a duplicate port-forward.